### PR TITLE
fix: sync design filter preview #4599

### DIFF
--- a/app/scripts/react/components/DesignPreview/index.jsx
+++ b/app/scripts/react/components/DesignPreview/index.jsx
@@ -10,8 +10,28 @@ import { isDesignOpened } from 'r/actions/popupActions';
 
 jss.use(nested);
 
+export function catalogFilterPreviewRule(value) {
+  if (value) return {};
+
+  return {
+    '.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__filter': {
+      display: 'none',
+    },
+    '.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__filter-container': {
+      display: 'none',
+    },
+    '.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__content': {
+      'margin-left': '-18px',
+    },
+    '.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__description': {
+      'margin-left': '6px',
+    },
+  };
+}
+
 const _rules = {
   welcome: {
+    mainPageFilter: catalogFilterPreviewRule,
     mainPageRows(value, { mainPageProductsInRow }) {
       const newValue = (value * mainPageProductsInRow) + 1;
 
@@ -23,6 +43,7 @@ const _rules = {
     },
   },
   categories: {
+    categoryPageFilter: catalogFilterPreviewRule,
     categoryPageRows(value, { categoryPageProductsInRow }) {
       const newValue = (value * categoryPageProductsInRow) + 1;
 

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ import './react/components/Userbar/index.test';
 import './react/components/Logo/Logo.test';
 import './react/components/Notice/Notice.test';
 import './react/components/DesignSettings/DesignSettings.test';
+import './react/components/DesignPreview/DesignPreview.test';
 import './react/components/Product/ProductCart/ProductCart.test';
 import './react/components/Product/ProductCard/ProductCardContainer.test';
 

--- a/test/react/components/DesignPreview/DesignPreview.test.js
+++ b/test/react/components/DesignPreview/DesignPreview.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { catalogFilterPreviewRule } from '../../../../app/scripts/react/components/DesignPreview';
+
+describe('[Component] DesignPreview', function() {
+  describe('catalogFilterPreviewRule', function() {
+    it('hides filter and resets list layout when filter switch is off', function() {
+      const rules = catalogFilterPreviewRule(false);
+
+      expect(rules).to.have.property('.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__filter');
+      expect(rules).to.have.property('.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__filter-container');
+      expect(rules['.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__filter']).to.deep.equal({ display: 'none' });
+      expect(rules['.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__filter-container']).to.deep.equal({ display: 'none' });
+      expect(rules['.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__content']).to.deep.equal({ 'margin-left': '-18px' });
+      expect(rules['.b-page .b-item-list_catalog.b-item-list--with-filter .b-item-list__description']).to.deep.equal({ 'margin-left': '6px' });
+    });
+
+    it('does not force a filter to appear when filter switch is on', function() {
+      expect(catalogFilterPreviewRule(true)).to.deep.equal({});
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Sync DesignPreview filter state with the rendered preview
- Add regression coverage for the filter preview update

## Context
Merchantly already pins vendor/static/public to commit 58fcc316d from this branch, so this PR brings front-public/master in line with the submodule reference.

Fixes #4599